### PR TITLE
feat: more efficient participants level deduplication

### DIFF
--- a/zoom_report/api/ragic.py
+++ b/zoom_report/api/ragic.py
@@ -52,7 +52,9 @@ class Ragic:
         response = requests.get(url, headers=self.__headers, params=params, timeout=timeout)
         return response
 
-    def __send_data(self, api_route: str, data: JSON, timeout: int = REQUEST_TIMEOUT) -> requests.Response:
+    def __send_data(
+        self, api_route: str, data: JSON, timeout: int = REQUEST_TIMEOUT
+    ) -> requests.Response:
         """
         Send data to the specified API route.
         :param api_route: an API route in Ragic

--- a/zoom_report/api/ragic.py
+++ b/zoom_report/api/ragic.py
@@ -11,7 +11,7 @@ from zoom_report.common.enums import Cogv
 from zoom_report.common.helpers import JSON
 from zoom_report.logger.pkg_logger import Logger
 
-REQUEST_TIMEOUT = 30
+REQUEST_TIMEOUT = 60
 
 
 class Ragic:
@@ -46,7 +46,7 @@ class Ragic:
         :param timeout: timeout the request after n seconds
         :returns: a response from Ragic
         """
-        if not self.validate_data(params):
+        if params and not self.validate_data(params):
             raise TypeError("Payload type check failed.")
         url = f"{self.__base_url}/{api_route}"
         response = requests.get(url, headers=self.__headers, params=params, timeout=timeout)
@@ -91,7 +91,7 @@ class Ragic:
         """
         route = Config.ragic_participants_route()
         filters = [f"{Cogv.SUB_MEETING_NUMBER},eq,{uuid}"]
-        return self.__get_data(route, params={"where": filters})
+        return self.__get_data(route, params={"where": filters}).json()
 
     def write_participant(self, uuid: str, participant_info: JSON) -> JSON:
         """

--- a/zoom_report/api/ragic.py
+++ b/zoom_report/api/ragic.py
@@ -2,6 +2,7 @@
 A wrapper for the Ragic API
 """
 from http import HTTPStatus
+from typing import Optional
 
 import requests
 
@@ -9,6 +10,8 @@ from zoom_report import Config
 from zoom_report.common.enums import Cogv
 from zoom_report.common.helpers import JSON
 from zoom_report.logger.pkg_logger import Logger
+
+REQUEST_TIMEOUT = 30
 
 
 class Ragic:
@@ -33,7 +36,9 @@ class Ragic:
                 return False
         return True
 
-    def __get_data(self, api_route: str, params: JSON = {}, timeout: int = 10) -> requests.Response:
+    def __get_data(
+        self, api_route: str, params: Optional[JSON] = None, timeout: int = REQUEST_TIMEOUT
+    ) -> requests.Response:
         """
         Get data from the specified API route.
         :param api_route: an API route in Ragic
@@ -47,7 +52,7 @@ class Ragic:
         response = requests.get(url, headers=self.__headers, params=params, timeout=timeout)
         return response
 
-    def __send_data(self, api_route: str, data: JSON, timeout: int = 10) -> requests.Response:
+    def __send_data(self, api_route: str, data: JSON, timeout: int = REQUEST_TIMEOUT) -> requests.Response:
         """
         Send data to the specified API route.
         :param api_route: an API route in Ragic

--- a/zoom_report/automate/storage.py
+++ b/zoom_report/automate/storage.py
@@ -22,7 +22,7 @@ def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, delay: float = API_D
     ragic = Ragic()
     Logger.info("Writing records to Ragic...")
     response = ragic.write_attendance(meeting_info)
-    if handle_api_status(response, "writing to attendance"):
+    if not handle_api_status(response, "writing to attendance"):
         participants = ragic.read_participants(meeting_info["uuid"])
         if participants:
             names = [
@@ -32,7 +32,6 @@ def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, delay: float = API_D
             ]
             Logger.info(f"Filtering out {len(names)} existing records...")
             frame = frame[~frame["name"].isin(names)]
-    else:
         Logger.warn("Attempting to update existing attendance...")
     for _, row in frame.iterrows():
         response = ragic.write_participant(meeting_info["uuid"], row)

--- a/zoom_report/automate/storage.py
+++ b/zoom_report/automate/storage.py
@@ -24,10 +24,14 @@ def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, delay: float = API_D
     response = ragic.write_attendance(meeting_info)
     if handle_api_status(response, "writing to attendance"):
         participants = ragic.read_participants(meeting_info["uuid"])
-        names = [
-            participant["Name"] for participant in participants.values() if "Name" in participant
-        ]
-        frame = frame[~frame["name"].isin(names)]
+        if participants:
+            names = [
+                participant["Name"]
+                for participant in participants.values()
+                if "Name" in participant
+            ]
+            Logger.info(f"Filtering out {len(names)} existing records...")
+            frame = frame[~frame["name"].isin(names)]
     else:
         Logger.warn("Attempting to update existing attendance...")
     for _, row in frame.iterrows():

--- a/zoom_report/automate/storage.py
+++ b/zoom_report/automate/storage.py
@@ -24,8 +24,10 @@ def write_to_ragic(
     """
     ragic = Ragic()
     Logger.info("Writing records to Ragic...")
+    # write attendance sheet if it doesn't exist
     response = ragic.write_attendance(meeting_info)
     if not handle_api_status(response, "writing to attendance"):
+        # append mode, remove existing Ragic records from frame
         participants = ragic.read_participants(meeting_info["uuid"])
         if participants:
             names = [
@@ -36,6 +38,7 @@ def write_to_ragic(
             Logger.info(f"Filtering out {len(names)} existing records...")
             frame = frame[~frame["name"].isin(names)]
         Logger.warn("Attempting to update existing attendance...")
+    # write unique attendance records into Ragic
     for _, row in frame.iterrows():
         response = ragic.write_participant(meeting_info["uuid"], row)
         if handle_api_status(response, "writing to participants"):

--- a/zoom_report/automate/storage.py
+++ b/zoom_report/automate/storage.py
@@ -24,7 +24,9 @@ def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, delay: float = API_D
     response = ragic.write_attendance(meeting_info)
     if handle_api_status(response, "writing to attendance"):
         participants = ragic.read_participants(meeting_info["uuid"])
-        names = [participant["Name"] for participant in participants if "Name" in participant]
+        names = [
+            participant["Name"] for participant in participants.values() if "Name" in participant
+        ]
         frame = frame[~frame["name"].isin(names)]
     else:
         Logger.warn("Attempting to update existing attendance...")

--- a/zoom_report/automate/storage.py
+++ b/zoom_report/automate/storage.py
@@ -2,6 +2,7 @@
 Write attendance data to storage
 """
 from time import sleep
+from typing import Union
 
 import pandas as pd
 
@@ -9,10 +10,12 @@ from zoom_report.logger.pkg_logger import Logger
 from zoom_report.api.ragic import Ragic
 from zoom_report.common.helpers import JSON, handle_api_status
 
-API_DELAY = 2.5
+API_DELAY = 2
 
 
-def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, delay: float = API_DELAY) -> bool:
+def write_to_ragic(
+    frame: pd.DataFrame, meeting_info: JSON, delay: Union[int, float] = API_DELAY
+) -> bool:
     """
     Write a given attendance report to a pre-configured route in Ragic.
     :param frame: a DataFrame with attendance data to write

--- a/zoom_report/automate/storage.py
+++ b/zoom_report/automate/storage.py
@@ -12,7 +12,7 @@ from zoom_report.common.helpers import JSON, handle_api_status
 API_DELAY = 2.5
 
 
-def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, api_delay: float = API_DELAY) -> bool:
+def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, delay: float = API_DELAY) -> bool:
     """
     Write a given attendance report to a pre-configured route in Ragic.
     :param frame: a DataFrame with attendance data to write
@@ -24,14 +24,14 @@ def write_to_ragic(frame: pd.DataFrame, meeting_info: JSON, api_delay: float = A
     response = ragic.write_attendance(meeting_info)
     if handle_api_status(response, "writing to attendance"):
         participants = ragic.read_participants(meeting_info["uuid"])
-        names = [participant["Name"] for participant in participants if "Name" if participant]
+        names = [participant["Name"] for participant in participants if "Name" in participant]
         frame = frame[~frame["name"].isin(names)]
     else:
         Logger.warn("Attempting to update existing attendance...")
     for _, row in frame.iterrows():
         response = ragic.write_participant(meeting_info["uuid"], row)
         if handle_api_status(response, "writing to participants"):
-            sleep(api_delay)  # wait a few seconds to avoid API limits
+            sleep(delay)  # wait a few seconds to avoid API limits
     return True
 
 

--- a/zoom_report/process/meetings.py
+++ b/zoom_report/process/meetings.py
@@ -83,6 +83,6 @@ def get_details(meeting_id: str) -> JSON:
     response = Zoom().get_meeting_details(meeting_id)
     if "code" in response:
         Logger.warn("An error occured when retrieving meeting details.")
-        Logger.error(response["message"])
+        Logger.error(response.get("message", "Unknown error."))
         return {}
     return response


### PR DESCRIPTION
This PR implements a more efficient participant level deduplication. Instead of checking if an attendance record exists in Ragic and write non-existing ones, we can simply get the list of all attendance records from Ragic and remove existing ones from the records to write. This reduces the number of API calls needed by roughly 1/2. As a result, we can decrease the delay between API calls.

We have also increased the number of seconds before timing out a request, to account for current network issues. This should make the script more reliable, allowing the server to have more time to recover connectivity.